### PR TITLE
Remove redundant push trigger from deploy-frontend workflow

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,9 +1,6 @@
 name: Deploy Frontend
 
 on:
-  push:
-    branches:
-      - main
   repository_dispatch:
     types: [trigger-frontend-build]
 


### PR DESCRIPTION
- Frontend deployment will now only be triggered by generate-data workflow
- Prevents duplicate workflow runs on code merge
- Maintains the sequential generate-then-deploy workflow